### PR TITLE
1.21.9/10/11 Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.loving11ish</groupId>
     <artifactId>EpicHomes</artifactId>
-    <version>1.1.3-ALPHA-01</version>
+    <version>1.1.3-BETA-01</version>
     <packaging>jar</packaging>
 
     <name>EpicHomes</name>
@@ -142,6 +142,10 @@
             <url>https://jitpack.io</url>
         </repository>
         <repository>
+            <id>tcoded-releases</id>
+            <url>https://repo.tcoded.com/releases</url>
+        </repository>
+        <repository>
             <id>maven_central</id>
             <name>Maven Central</name>
             <url>https://repo.maven.apache.org/maven2/</url>
@@ -160,9 +164,9 @@
 
         <!-- FoliaLib is shaded in via maven-shade -->
         <dependency>
-            <groupId>com.github.technicallycoded</groupId>
+            <groupId>com.tcoded</groupId>
             <artifactId>FoliaLib</artifactId>
-            <version>0.4.4</version>
+            <version>0.5.1</version>
             <scope>compile</scope>
         </dependency>
 
@@ -177,20 +181,20 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.19.0</version>
+            <version>4.25.0</version>
             <scope>compile</scope>
         </dependency>
         <!-- Adventure-platform-bukkit is shaded in via maven-shade -->
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bukkit</artifactId>
-            <version>4.3.4</version>
+            <version>4.4.1</version>
         </dependency>
         <!-- adventure-text-minimessage is shaded in via maven-shade -->
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
-            <version>4.19.0</version>
+            <version>4.25.0</version>
             <scope>compile</scope>
         </dependency>
 
@@ -199,7 +203,7 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>24.1.0</version>
+            <version>26.0.2-1</version>
             <scope>provided</scope>
         </dependency>
 
@@ -208,14 +212,14 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.17.0</version>
+            <version>1.19.0</version>
             <scope>provided</scope>
         </dependency>
         <!-- Commons-lang3 is provided by external lib download -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.15.0</version>
+            <version>3.18.0</version>
             <scope>provided</scope>
         </dependency>
 
@@ -224,7 +228,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.10</version>
+            <version>2.13.2</version>
             <scope>provided</scope>
         </dependency>
 
@@ -232,7 +236,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.11.6</version>
+            <version>2.11.7</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.loving11ish</groupId>
     <artifactId>EpicHomes</artifactId>
-    <version>1.1.3-BETA-01</version>
+    <version>1.1.3</version>
     <packaging>jar</packaging>
 
     <name>EpicHomes</name>
@@ -121,6 +121,10 @@
     </build>
 
     <repositories>
+        <repository>
+            <id>codemc-releases</id>
+            <url>https://repo.codemc.io/repository/maven-releases/</url>
+        </repository>
         <repository>
             <id>papermc</id>
             <url>https://papermc.io/repo/repository/maven-public/</url>

--- a/src/main/java/me/loving11ish/epichomes/EpicHomes.java
+++ b/src/main/java/me/loving11ish/epichomes/EpicHomes.java
@@ -38,10 +38,10 @@ public final class EpicHomes extends JavaPlugin {
 
     private static EpicHomes plugin;
     private static FoliaLib foliaLib;
-    private static ServerVersion serverVersion;
-    private static BukkitAudiences bukkitAudiences;
-    private static VersionCheckerUtils versionCheckerUtils;
-    private static PlaceholderAPIHook placeholderAPIHook = null;
+    private ServerVersion serverVersion;
+    private BukkitAudiences bukkitAudiences;
+    private VersionCheckerUtils versionCheckerUtils;
+    private PlaceholderAPIHook placeholderAPIHook = null;
 
     private boolean isPluginEnabled = true;
     private boolean isOnlineMode = true;
@@ -86,8 +86,8 @@ public final class EpicHomes extends JavaPlugin {
         setUsermapFileManager(new UsermapFileManager(this));
 
         // Check server version and set it
-        setVersion();
         versionCheckerUtils = new VersionCheckerUtils();
+        versionCheckerUtils.getServerVersion();
         versionCheckerUtils.setVersion();
 
         // Server version compatibility check
@@ -380,36 +380,6 @@ public final class EpicHomes extends JavaPlugin {
         }
     }
 
-    private void setVersion() {
-        try {
-            String packageName = Bukkit.getServer().getClass().getPackage().getName();
-            String bukkitVersion = Bukkit.getServer().getBukkitVersion();
-            if (bukkitVersion.contains("1.20.5")) {
-                serverVersion = ServerVersion.v1_20_R5;
-            } else if (bukkitVersion.contains("1.20.6")) {
-                serverVersion = ServerVersion.v1_20_R5;
-            } else if (bukkitVersion.contains("1.21")) {
-                serverVersion = ServerVersion.v1_21_R1;
-            } else if (bukkitVersion.contains("1.21.1")) {
-                serverVersion = ServerVersion.v1_21_R2;
-            } else if (bukkitVersion.contains("1.21.2")) {
-                serverVersion = ServerVersion.v1_21_R3;
-            } else if (bukkitVersion.contains("1.21.3")) {
-                serverVersion = ServerVersion.v1_21_R4;
-            } else if (bukkitVersion.contains("1.21.4")) {
-                serverVersion = ServerVersion.v1_21_R5;
-            } else if (bukkitVersion.contains("1.21.5")) {
-                serverVersion = ServerVersion.v1_21_R6;
-            } else {
-                serverVersion = ServerVersion.valueOf(packageName.replace("org.bukkit.craftbukkit.", ""));
-            }
-        } catch (Exception e) {
-            serverVersion = ServerVersion.Other;
-            MessageUtils.sendDebugConsole("Failed to detect server version, defaulting to: " + serverVersion);
-        }
-        MessageUtils.sendDebugConsole("Set server version: " + serverVersion);
-    }
-
     public static EpicHomes getPlugin() {
         return plugin;
     }
@@ -418,15 +388,19 @@ public final class EpicHomes extends JavaPlugin {
         return foliaLib;
     }
 
-    public static ServerVersion getServerVersion() {
+    public ServerVersion getServerVersion() {
         return serverVersion;
+    }
+
+    public void setServerVersion(ServerVersion serverVersion) {
+        this.serverVersion = serverVersion;
     }
 
     public BukkitAudiences getBukkitAudiences() {
         return bukkitAudiences;
     }
 
-    public static VersionCheckerUtils getVersionCheckerUtils() {
+    public VersionCheckerUtils getVersionCheckerUtils() {
         return versionCheckerUtils;
     }
 

--- a/src/main/java/me/loving11ish/epichomes/api/EpicHomesAPI.java
+++ b/src/main/java/me/loving11ish/epichomes/api/EpicHomesAPI.java
@@ -55,14 +55,14 @@ public class EpicHomesAPI {
      * @return Returns a string of text that contains the full server package.
      */
     public static String getServerPackage() {
-        return EpicHomes.getVersionCheckerUtils().getServerPackage();
+        return EpicHomes.getPlugin().getVersionCheckerUtils().getServerPackage();
     }
 
     /**
      * @return Returns an integer that is the base major server version.
      */
     public static int getMajorServerVersion() {
-        return EpicHomes.getVersionCheckerUtils().getVersion();
+        return EpicHomes.getPlugin().getVersionCheckerUtils().getVersion();
     }
 
     /**

--- a/src/main/java/me/loving11ish/epichomes/commands/subcommands/SetSubCommand.java
+++ b/src/main/java/me/loving11ish/epichomes/commands/subcommands/SetSubCommand.java
@@ -15,6 +15,7 @@ import org.bukkit.entity.Player;
 import java.util.List;
 import java.util.Map;
 
+@SuppressWarnings("deprecation")
 public class SetSubCommand {
 
     private final FoliaLib foliaLib = EpicHomes.getFoliaLib();

--- a/src/main/java/me/loving11ish/epichomes/externalhooks/PlaceholderAPIHook.java
+++ b/src/main/java/me/loving11ish/epichomes/externalhooks/PlaceholderAPIHook.java
@@ -57,12 +57,12 @@ public class PlaceholderAPIHook extends PlaceholderExpansion {
 
         if (params.equalsIgnoreCase("baseServerVersion")){
             //%epicHomes_baseServerVersion%
-            return String.valueOf(EpicHomes.getVersionCheckerUtils().getVersion());
+            return String.valueOf(EpicHomes.getPlugin().getVersionCheckerUtils().getVersion());
         }
 
         if (params.equalsIgnoreCase("serverPackage")){
             //%epicHomes_serverPackage%
-            return EpicHomes.getVersionCheckerUtils().getServerPackage();
+            return EpicHomes.getPlugin().getVersionCheckerUtils().getServerPackage();
         }
 
         if (params.equalsIgnoreCase("pluginEnabled")){

--- a/src/main/java/me/loving11ish/epichomes/utils/VersionCheckerUtils.java
+++ b/src/main/java/me/loving11ish/epichomes/utils/VersionCheckerUtils.java
@@ -1,6 +1,7 @@
 package me.loving11ish.epichomes.utils;
 
 import me.loving11ish.epichomes.EpicHomes;
+import me.loving11ish.epichomes.versionsystems.ServerVersion;
 import org.bukkit.Bukkit;
 
 import java.util.regex.PatternSyntaxException;
@@ -21,7 +22,7 @@ public class VersionCheckerUtils {
 
     public void setVersion() {
         try {
-            version = EpicHomes.getServerVersion().getServerMajorVersionNumber();
+            version = EpicHomes.getPlugin().getServerVersion().getServerMajorVersionNumber();
             versionCheckedSuccessfully = true;
         } catch (NumberFormatException | PatternSyntaxException e) {
             versionCheckedSuccessfully = false;
@@ -29,8 +30,76 @@ public class VersionCheckerUtils {
             MessageUtils.sendConsole("&4Unable to process server version!");
             MessageUtils.sendConsole("&4Some features may break unexpectedly!");
             MessageUtils.sendConsole("&4Report any issues to the developer!");
+            MessageUtils.sendDebugConsole("error", "&4-------------------------------------------");
+            MessageUtils.sendDebugConsole("error", "Cause: " + e.getCause());
+            MessageUtils.sendDebugConsole("error", "Message: " +e.getMessage());
+            MessageUtils.sendDebugConsole("error", "&4-------------------------------------------");
             MessageUtils.sendConsole("&c-------------------------------------------");
         }
+    }
+
+    public void getServerVersion() {
+        try {
+            String bukkitVersion = Bukkit.getServer().getBukkitVersion();
+            String normalizedVersion = bukkitVersion.split("-")[0]; // Extract base version
+
+            MessageUtils.sendDebugConsole("-----------------------------------------");
+            MessageUtils.sendDebugConsole("Detected Bukkit version: " + bukkitVersion);
+            MessageUtils.sendDebugConsole("Normalized version: " + normalizedVersion);
+
+            switch (normalizedVersion) {
+                case "1.20.5":
+                    EpicHomes.getPlugin().setServerVersion(ServerVersion.v1_20_R4);
+                    break;
+                case "1.20.6":
+                    EpicHomes.getPlugin().setServerVersion(ServerVersion.v1_20_R5);
+                    break;
+                case "1.21":
+                    EpicHomes.getPlugin().setServerVersion(ServerVersion.v1_21_R1);
+                    break;
+                case "1.21.1":
+                    EpicHomes.getPlugin().setServerVersion(ServerVersion.v1_21_R2);
+                    break;
+                case "1.21.2":
+                    EpicHomes.getPlugin().setServerVersion(ServerVersion.v1_21_R3);
+                    break;
+                case "1.21.3":
+                    EpicHomes.getPlugin().setServerVersion(ServerVersion.v1_21_R4);
+                    break;
+                case "1.21.4":
+                    EpicHomes.getPlugin().setServerVersion(ServerVersion.v1_21_R5);
+                    break;
+                case "1.21.5":
+                    EpicHomes.getPlugin().setServerVersion(ServerVersion.v1_21_R6);
+                    break;
+                case "1.21.6":
+                    EpicHomes.getPlugin().setServerVersion(ServerVersion.v1_21_R7);
+                    break;
+                case "1.21.7":
+                    EpicHomes.getPlugin().setServerVersion(ServerVersion.v1_21_R8);
+                    break;
+                case "1.21.8":
+                    EpicHomes.getPlugin().setServerVersion(ServerVersion.v1_21_R9);
+                    break;
+                case "1.21.9":
+                    EpicHomes.getPlugin().setServerVersion(ServerVersion.v1_21_R10);
+                    break;
+                case "1.21.10":
+                    EpicHomes.getPlugin().setServerVersion(ServerVersion.v1_21_R11);
+                    break;
+
+
+                default:
+                    String packageName = Bukkit.getServer().getClass().getPackage().getName();
+                    EpicHomes.getPlugin().setServerVersion(ServerVersion.valueOf(packageName.replace("org.bukkit.craftbukkit.", "")));
+                    break;
+            }
+
+        } catch (Exception e) {
+            EpicHomes.getPlugin().setServerVersion(ServerVersion.Other);
+            MessageUtils.sendDebugConsole("Failed to detect server version, defaulting to: " + EpicHomes.getPlugin().getServerVersion());
+        }
+        MessageUtils.sendDebugConsole("Set server version: " + EpicHomes.getPlugin().getServerVersion());
     }
 
     public String getServerPackage() {

--- a/src/main/java/me/loving11ish/epichomes/utils/VersionCheckerUtils.java
+++ b/src/main/java/me/loving11ish/epichomes/utils/VersionCheckerUtils.java
@@ -87,6 +87,9 @@ public class VersionCheckerUtils {
                 case "1.21.10":
                     EpicHomes.getPlugin().setServerVersion(ServerVersion.v1_21_R11);
                     break;
+                case "1.21.11":
+                    EpicHomes.getPlugin().setServerVersion(ServerVersion.v1_21_R12);
+                    break;
 
 
                 default:

--- a/src/main/java/me/loving11ish/epichomes/versionsystems/ServerVersion.java
+++ b/src/main/java/me/loving11ish/epichomes/versionsystems/ServerVersion.java
@@ -34,6 +34,11 @@ public enum ServerVersion {
     v1_21_R4,
     v1_21_R5,
     v1_21_R6,
+    v1_21_R7,
+    v1_21_R8,
+    v1_21_R9,
+    v1_21_R10,
+    v1_21_R11,
     Other;
 
     public boolean serverVersionEqual(ServerVersion version) {

--- a/src/main/java/me/loving11ish/epichomes/versionsystems/ServerVersion.java
+++ b/src/main/java/me/loving11ish/epichomes/versionsystems/ServerVersion.java
@@ -39,6 +39,7 @@ public enum ServerVersion {
     v1_21_R9,
     v1_21_R10,
     v1_21_R11,
+    v1_21_R12,
     Other;
 
     public boolean serverVersionEqual(ServerVersion version) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,8 +2,8 @@ name: EpicHomes
 version: '${project.version}'
 main: me.loving11ish.epichomes.EpicHomes
 libraries:
-  - 'commons-codec:commons-codec:1.17.0'
-  - 'org.apache.commons:commons-lang3:3.15.0'
+  - 'commons-codec:commons-codec:1.19.0'
+  - 'org.apache.commons:commons-lang3:3.18.0'
 api-version: 1.13
 folia-supported: true
 load: POSTWORLD


### PR DESCRIPTION
- Updated GitHub repository. 
- Updated ALL plugin dependencies. 
- Moved startup version checks to separate class. 
- Added support for MC `1.21.6`. 
- Added support for MC `1.21.7`. 
- Added support for MC `1.21.8`. 
- Added support for MC `1.21.9`. 
- Added support for MC `1.21.10`. 
- Changed plugin version to `1.1.3-BETA-01`.